### PR TITLE
added Topaz intel & sgi Makefiles and changed SYSTEM call for RESULT …

### DIFF
--- a/Makefile-Topaz-intel
+++ b/Makefile-Topaz-intel
@@ -1,0 +1,102 @@
+#-----------BEGIN MAKEFILE-------------------------------------------------
+            SHELL         = /bin/sh
+            DEF_FLAGS     = -P -traditional 
+            EXEC          = funwave_intel
+#==========================================================================
+#--------------------------------------------------------------------------
+#        PRECISION          DEFAULT PRECISION: SINGLE                     
+#                           UNCOMMENT TO SELECT DOUBLE PRECISION
+#--------------------------------------------------------------------------
+
+            FLAG_1 = -DDOUBLE_PRECISION 
+            FLAG_2 = -DPARALLEL
+            FLAG_3 = -DSAMPLES
+            FLAG_4 = -DCARTESIAN
+              FLAG_6 = -DINTEL
+#             FLAG_7 = -DMIXING
+#             FLAG_8 = -DCOUPLING
+#             FLAG_9 = -DZALPHA
+#             FLAG_10 = -DMANNING
+
+#--------------------------------------------------------------------------
+#  mpi defs 
+#--------------------------------------------------------------------------
+         CPP      = /usr/bin/cpp 
+         CPPFLAGS = $(DEF_FLAGS)
+         FC       = mpiifort
+         DEBFLGS  = 
+         OPT      = 
+         CLIB     = 
+#==========================================================================
+
+         FFLAGS = $(DEBFLGS) $(OPT) #-fPIC -g -O2
+         MDEPFLAGS = --cpp --fext=f90 --file=-
+         RANLIB = ranlib
+	 MPILIB = # -lmpi
+#--------------------------------------------------------------------------
+#  CAT Preprocessing Flags
+#--------------------------------------------------------------------------
+           CPPARGS = $(CPPFLAGS) $(DEF_FLAGS) $(FLAG_1) $(FLAG_2) \
+			$(FLAG_3) $(FLAG_4) $(FLAG_5) $(FLAG_6) \
+			$(FLAG_7) $(FLAG_8) $(FLAG_9) $(FLAG_10)  \
+			$(FLAG_11) $(FLAG_12) $(FLAG_13) $(FLAG_14) \
+			$(FLAG_15) $(FLAG_16) $(FLAG_17) $(FLAG_18) \
+			$(FLAG_19) $(FLAG_20) $(FLAG_21) $(FLAG_22) \
+			$(FLAG_23) $(FLAG_24)
+#--------------------------------------------------------------------------
+#  Libraries           
+#--------------------------------------------------------------------------
+
+            LIBS  = $(PV3LIB) $(CLIB)  $(PARLIB) $(IOLIBS) $(MPILIB) $(GOTMLIB)
+#            INCS  = $(IOINCS) $(GOTMINCS)
+
+
+#--------------------------------------------------------------------------
+#  Preprocessing and Compilation Directives
+#--------------------------------------------------------------------------
+.SUFFIXES: .o .f90 .F .F90 
+
+.F.o:
+	$(CPP) $(CPPARGS) $*.F > $*.f90
+	$(FC)  -c $(FFLAGS) $(INCS) $*.f90
+#	\rm $*.f90
+#--------------------------------------------------------------------------
+#  FUNWAVE-TVD Source Code.
+#--------------------------------------------------------------------------
+
+MODS  = mod_param.F	mod_global.F	mod_input.F \
+
+MAIN  = main.F bc.F fluxes.F init.F io.F tridiagnal.F       \
+        breaker.F derivatives.F dispersion.F etauv_solver.F \
+        sponge.F sources.F masks.F parallel.F statistics.F \
+        wavemaker.F mixing.F nesting.F misc.F samples.F\
+
+SRCS = $(MODS)  $(MAIN)
+
+OBJS = $(SRCS:.F=.o)
+
+#--------------------------------------------------------------------------
+#  Linking Directives               
+#--------------------------------------------------------------------------
+
+$(EXEC):	$(OBJS)
+		$(FC) $(FFLAGS) $(LDFLAGS) -o $(EXEC) $(OBJS) $(LIBS) -Bdynamic
+		mv $(EXEC) ../bin/
+#--------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------
+#  Tar Up Code                           
+#--------------------------------------------------------------------------
+
+tarfile:
+	tar cvf funwave_tvd.tar *.F  Makefile
+
+#--------------------------------------------------------------------------
+#  Cleaning targets.
+#--------------------------------------------------------------------------
+
+clean:
+		/bin/rm -f *.o *.mod
+
+clobber:	clean
+		/bin/rm -f *.f90 *.o mytvd

--- a/Makefile-Topaz-sgi
+++ b/Makefile-Topaz-sgi
@@ -1,0 +1,102 @@
+#-----------BEGIN MAKEFILE-------------------------------------------------
+            SHELL         = /bin/sh
+            DEF_FLAGS     = -P -traditional 
+            EXEC          = funwave_sgi
+#==========================================================================
+#--------------------------------------------------------------------------
+#        PRECISION          DEFAULT PRECISION: SINGLE                     
+#                           UNCOMMENT TO SELECT DOUBLE PRECISION
+#--------------------------------------------------------------------------
+
+            FLAG_1 = -DDOUBLE_PRECISION 
+            FLAG_2 = -DPARALLEL
+            FLAG_3 = -DSAMPLES
+            FLAG_4 = -DCARTESIAN
+              FLAG_6 = -DINTEL
+#             FLAG_7 = -DMIXING
+#             FLAG_8 = -DCOUPLING
+#             FLAG_9 = -DZALPHA
+#             FLAG_10 = -DMANNING
+
+#--------------------------------------------------------------------------
+#  mpi defs 
+#--------------------------------------------------------------------------
+         CPP      = /usr/bin/cpp 
+         CPPFLAGS = $(DEF_FLAGS)
+         FC       = ifort
+         DEBFLGS  = 
+         OPT      = 
+         CLIB     = 
+#==========================================================================
+
+         FFLAGS = $(DEBFLGS) $(OPT) #-fPIC -g -O2
+         MDEPFLAGS = --cpp --fext=f90 --file=-
+         RANLIB = ranlib
+	 MPILIB = -lmpi
+#--------------------------------------------------------------------------
+#  CAT Preprocessing Flags
+#--------------------------------------------------------------------------
+           CPPARGS = $(CPPFLAGS) $(DEF_FLAGS) $(FLAG_1) $(FLAG_2) \
+			$(FLAG_3) $(FLAG_4) $(FLAG_5) $(FLAG_6) \
+			$(FLAG_7) $(FLAG_8) $(FLAG_9) $(FLAG_10)  \
+			$(FLAG_11) $(FLAG_12) $(FLAG_13) $(FLAG_14) \
+			$(FLAG_15) $(FLAG_16) $(FLAG_17) $(FLAG_18) \
+			$(FLAG_19) $(FLAG_20) $(FLAG_21) $(FLAG_22) \
+			$(FLAG_23) $(FLAG_24)
+#--------------------------------------------------------------------------
+#  Libraries           
+#--------------------------------------------------------------------------
+
+            LIBS  = $(PV3LIB) $(CLIB)  $(PARLIB) $(IOLIBS) $(MPILIB) $(GOTMLIB)
+#            INCS  = $(IOINCS) $(GOTMINCS)
+
+
+#--------------------------------------------------------------------------
+#  Preprocessing and Compilation Directives
+#--------------------------------------------------------------------------
+.SUFFIXES: .o .f90 .F .F90 
+
+.F.o:
+	$(CPP) $(CPPARGS) $*.F > $*.f90
+	$(FC)  -c $(FFLAGS) $(INCS) $*.f90
+#	\rm $*.f90
+#--------------------------------------------------------------------------
+#  FUNWAVE-TVD Source Code.
+#--------------------------------------------------------------------------
+
+MODS  = mod_param.F	mod_global.F	mod_input.F \
+
+MAIN  = main.F bc.F fluxes.F init.F io.F tridiagnal.F       \
+        breaker.F derivatives.F dispersion.F etauv_solver.F \
+        sponge.F sources.F masks.F parallel.F statistics.F \
+        wavemaker.F mixing.F nesting.F misc.F samples.F\
+
+SRCS = $(MODS)  $(MAIN)
+
+OBJS = $(SRCS:.F=.o)
+
+#--------------------------------------------------------------------------
+#  Linking Directives               
+#--------------------------------------------------------------------------
+
+$(EXEC):	$(OBJS)
+		$(FC) $(FFLAGS) $(LDFLAGS) -o $(EXEC) $(OBJS) $(LIBS) -Bdynamic
+		mv $(EXEC) ../bin/
+#--------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------
+#  Tar Up Code                           
+#--------------------------------------------------------------------------
+
+tarfile:
+	tar cvf funwave_tvd.tar *.F  Makefile
+
+#--------------------------------------------------------------------------
+#  Cleaning targets.
+#--------------------------------------------------------------------------
+
+clean:
+		/bin/rm -f *.o *.mod
+
+clobber:	clean
+		/bin/rm -f *.f90 *.o mytvd

--- a/io.F
+++ b/io.F
@@ -206,10 +206,18 @@ SUBROUTINE READ_INPUT
       MKFOLDER = "mkdir -p "//TRIM(RESULT_FOLDER)
 # if defined (PARALLEL)
       IF (myid.eq.0) THEN
+# if defined (INTEL)
+        RES = SYSTEM(TRIM(MKFOLDER))
+# else
         CALL SYSTEM(TRIM(MKFOLDER))
+# endif
       ENDIF
 # else
+# if defined(INTEL)
+      RES = SYSTEM(TRIM(MKFOLDER))
+# else
       CALL SYSTEM(TRIM(MKFOLDER))
+# endif
 # endif
 
 ! station files

--- a/mod_global.F
+++ b/mod_global.F
@@ -52,7 +52,6 @@
 MODULE GLOBAL
        USE PARAM
        IMPLICIT NONE
-
        SAVE
 
 # if defined (PARALLEL)

--- a/mod_input.F
+++ b/mod_input.F
@@ -51,12 +51,13 @@
 !-------------------------------------------------------------------------------------
 
 MODULE INPUT_READ
+
 USE PARAM,ONLY : SP
 #if defined (PARALLEL)
   USE GLOBAL,ONLY : myid,ier
   USE MPI
 # endif
-IMPLICIT NONE
+  IMPLICIT NONE
   LOGICAL :: FILE_EXIST
   CHARACTER(LEN=80) :: VAL_TYPE 
   CHARACTER(LEN=80) :: VAL_READ 

--- a/mod_param.F
+++ b/mod_param.F
@@ -50,12 +50,11 @@
 !          the module is updated corresponding to modifications in subroutines
 !-------------------------------------------------------------------------------------
 
-MODULE PARAM
+MODULE PARAM  
 # if defined PARALLEL
        USE MPI
 # endif
-       IMPLICIT NONE
-
+       IMPLICIT NONE    
 # if defined DOUBLE_PRECISION 
        INTEGER, PARAMETER::SP=8
 # if defined PARALLEL
@@ -79,7 +78,7 @@ MODULE PARAM
        REAL(SP), PARAMETER:: DEG2RAD = 0.0175_SP
 
 ! some global variables
-       INTEGER :: I,J,K
+       INTEGER :: I,J,K, RES
        INTEGER :: itmp1,itmp2,itmp3,itmp4,itmp5
        REAL(SP):: tmp1,tmp2,tmp3,tmp4,tmp5
 

--- a/mod_vessel.F
+++ b/mod_vessel.F
@@ -61,7 +61,7 @@ MODULE VESSEL_MODULE
   USE GLOBAL,ONLY : myid,ier, npx,npy,PX,PY
   USE MPI
 # endif
-IMPLICIT NONE
+  IMPLICIT NONE
   SAVE
 
     INTEGER :: NumVessel,Kves

--- a/tridiagnal.F
+++ b/tridiagnal.F
@@ -57,7 +57,6 @@
 !-----------------------------------------------------------------------------------
 
     SUBROUTINE TRIDy_periodic ( a, c, d, f)
-
     USE PARAM
 
 # if defined (PARALLEL)
@@ -66,7 +65,6 @@
     USE MPI
 # endif
     USE GLOBAL, ONLY : Mloc, Nloc, Ibeg, Iend, Jbeg, Jend
-
     IMPLICIT NONE
 
 # if defined (PARALLEL)


### PR DESCRIPTION
@fengyanshi: I added Topaz intel & sgi Makefiles and changed `SYSTEM` call for RESULT folder to work for INTEL compiler `#if defined (INTEL)` in `io.F`. And for Intel the program you can try

`USE IFPORT
	...
res = SYSTEM(command)`

which is a function.

Overall, because `SYSTEM()` is not part of the Fortran standard, it may be implemented differently by different compilers as an extra feature.

I've also ran into issues on our HPC system when it came to `USE MPI` command. If the module mpi.mod has been compiled with a different version of MPI it can present a problem if the current compiler being used is a different version. In the future it would be generally best to replace with `INCLUDE 'mpif.h`, but then you have to shuffle the other `USE` and `IMPLICIT NONE` statements around as their current placement will generate an error.
