### PR TITLE
cleaned up io.F, fluxes.F and added two Makefiles for Lightning

### DIFF
--- a/src/Makefile-Lightning-Cray
+++ b/src/Makefile-Lightning-Cray
@@ -1,0 +1,104 @@
+#-----------BEGIN MAKEFILE-------------------------------------------------
+            SHELL         = /bin/sh
+            DEF_FLAGS     = -P -traditional 
+            EXEC          = funwave_cray
+#==========================================================================
+#--------------------------------------------------------------------------
+#        PRECISION          DEFAULT PRECISION: SINGLE                     
+#                           UNCOMMENT TO SELECT DOUBLE PRECISION
+#--------------------------------------------------------------------------
+
+            FLAG_1 = -DDOUBLE_PRECISION 
+            FLAG_2 = -DPARALLEL
+            FLAG_3 = -DSAMPLES
+            FLAG_4 = -DCARTESIAN
+	    FLAG_5 = -DCRAY
+#              FLAG_6 = -DINTEL
+#             FLAG_7 = -DMIXING
+#             FLAG_8 = -DCOUPLING
+#             FLAG_9 = -DZALPHA
+#             FLAG_10 = -DMANNING
+
+#--------------------------------------------------------------------------
+#  mpi defs 
+#--------------------------------------------------------------------------
+         CPP      = /usr/bin/cpp 
+         CPPFLAGS = $(DEF_FLAGS)
+         FC       = ftn
+         DEBFLGS  = 
+         OPT      = 
+         CLIB     = 
+#==========================================================================
+
+         FFLAGS = $(DEBFLGS) $(OPT) #-fPIC -g -O2
+         MDEPFLAGS = --cpp --fext=f90 --file=-
+         RANLIB = ranlib
+	 MPILIB = # -lmpi
+#--------------------------------------------------------------------------
+#  CAT Preprocessing Flags
+#--------------------------------------------------------------------------
+           CPPARGS = $(CPPFLAGS) $(DEF_FLAGS) $(FLAG_1) $(FLAG_2) \
+			$(FLAG_3) $(FLAG_4) $(FLAG_5) $(FLAG_6) \
+			$(FLAG_7) $(FLAG_8) $(FLAG_9) $(FLAG_10)  \
+			$(FLAG_11) $(FLAG_12) $(FLAG_13) $(FLAG_14) \
+			$(FLAG_15) $(FLAG_16) $(FLAG_17) $(FLAG_18) \
+			$(FLAG_19) $(FLAG_20) $(FLAG_21) $(FLAG_22) \
+			$(FLAG_23) $(FLAG_24)
+#--------------------------------------------------------------------------
+#  Libraries           
+#--------------------------------------------------------------------------
+
+            LIBS  = $(PV3LIB) $(CLIB)  $(PARLIB) $(IOLIBS) $(MPILIB) $(GOTMLIB)
+#            INCS  = $(IOINCS) $(GOTMINCS)
+
+
+#--------------------------------------------------------------------------
+#  Preprocessing and Compilation Directives
+#--------------------------------------------------------------------------
+.SUFFIXES: .o .f90 .F .F90 
+
+.F.o:
+	$(CPP) $(CPPARGS) $*.F > $*.f90
+	$(FC)  -c $(FFLAGS) $(INCS) $*.f90
+#	\rm $*.f90
+#--------------------------------------------------------------------------
+#  FUNWAVE-TVD Source Code.
+#--------------------------------------------------------------------------
+
+MODS  = mod_param.F	mod_global.F	mod_input.F \
+
+MAIN  = main.F bc.F fluxes.F init.F io.F tridiagnal.F       \
+        breaker.F derivatives.F dispersion.F etauv_solver.F \
+        sponge.F sources.F masks.F parallel.F statistics.F \
+        wavemaker.F mixing.F nesting.F misc.F samples.F\
+
+SRCS = $(MODS)  $(MAIN)
+
+OBJS = $(SRCS:.F=.o)
+
+#--------------------------------------------------------------------------
+#  Linking Directives               
+#--------------------------------------------------------------------------
+
+$(EXEC):	$(OBJS)
+		$(FC) $(FFLAGS) $(LDFLAGS) -o $(EXEC) $(OBJS) $(LIBS) -Bdynamic
+		mv $(EXEC) ../bin/
+#--------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------
+#  Tar Up Code                           
+#--------------------------------------------------------------------------
+
+tarfile:
+	tar cvf funwave_tvd.tar *.F  Makefile
+
+#--------------------------------------------------------------------------
+#  Cleaning targets.
+#--------------------------------------------------------------------------
+
+clean:
+		/bin/rm -f *.o *.mod
+
+clobber:	clean
+		/bin/rm -f *.f90 *.o $(EXEC)
+

--- a/src/Makefile-Lightning-Intel
+++ b/src/Makefile-Lightning-Intel
@@ -1,0 +1,104 @@
+#-----------BEGIN MAKEFILE-------------------------------------------------
+            SHELL         = /bin/sh
+            DEF_FLAGS     = -P -traditional 
+            EXEC          = funwave_intel
+#==========================================================================
+#--------------------------------------------------------------------------
+#        PRECISION          DEFAULT PRECISION: SINGLE                     
+#                           UNCOMMENT TO SELECT DOUBLE PRECISION
+#--------------------------------------------------------------------------
+
+            FLAG_1 = -DDOUBLE_PRECISION 
+            FLAG_2 = -DPARALLEL
+            FLAG_3 = -DSAMPLES
+            FLAG_4 = -DCARTESIAN
+#	    FLAG_5 = -DCRAY
+              FLAG_6 = -DINTEL
+#             FLAG_7 = -DMIXING
+#             FLAG_8 = -DCOUPLING
+#             FLAG_9 = -DZALPHA
+#             FLAG_10 = -DMANNING
+
+#--------------------------------------------------------------------------
+#  mpi defs 
+#--------------------------------------------------------------------------
+         CPP      = /usr/bin/cpp 
+         CPPFLAGS = $(DEF_FLAGS)
+         FC       = ftn
+         DEBFLGS  = 
+         OPT      = 
+         CLIB     = 
+#==========================================================================
+
+         FFLAGS = $(DEBFLGS) $(OPT) #-fPIC -g -O2
+         MDEPFLAGS = --cpp --fext=f90 --file=-
+         RANLIB = ranlib
+	 MPILIB = # -lmpi
+#--------------------------------------------------------------------------
+#  CAT Preprocessing Flags
+#--------------------------------------------------------------------------
+           CPPARGS = $(CPPFLAGS) $(DEF_FLAGS) $(FLAG_1) $(FLAG_2) \
+			$(FLAG_3) $(FLAG_4) $(FLAG_5) $(FLAG_6) \
+			$(FLAG_7) $(FLAG_8) $(FLAG_9) $(FLAG_10)  \
+			$(FLAG_11) $(FLAG_12) $(FLAG_13) $(FLAG_14) \
+			$(FLAG_15) $(FLAG_16) $(FLAG_17) $(FLAG_18) \
+			$(FLAG_19) $(FLAG_20) $(FLAG_21) $(FLAG_22) \
+			$(FLAG_23) $(FLAG_24)
+#--------------------------------------------------------------------------
+#  Libraries           
+#--------------------------------------------------------------------------
+
+            LIBS  = $(PV3LIB) $(CLIB)  $(PARLIB) $(IOLIBS) $(MPILIB) $(GOTMLIB)
+#            INCS  = $(IOINCS) $(GOTMINCS)
+
+
+#--------------------------------------------------------------------------
+#  Preprocessing and Compilation Directives
+#--------------------------------------------------------------------------
+.SUFFIXES: .o .f90 .F .F90 
+
+.F.o:
+	$(CPP) $(CPPARGS) $*.F > $*.f90
+	$(FC)  -c $(FFLAGS) $(INCS) $*.f90
+#	\rm $*.f90
+#--------------------------------------------------------------------------
+#  FUNWAVE-TVD Source Code.
+#--------------------------------------------------------------------------
+
+MODS  = mod_param.F	mod_global.F	mod_input.F \
+
+MAIN  = main.F bc.F fluxes.F init.F io.F tridiagnal.F       \
+        breaker.F derivatives.F dispersion.F etauv_solver.F \
+        sponge.F sources.F masks.F parallel.F statistics.F \
+        wavemaker.F mixing.F nesting.F misc.F samples.F\
+
+SRCS = $(MODS)  $(MAIN)
+
+OBJS = $(SRCS:.F=.o)
+
+#--------------------------------------------------------------------------
+#  Linking Directives               
+#--------------------------------------------------------------------------
+
+$(EXEC):	$(OBJS)
+		$(FC) $(FFLAGS) $(LDFLAGS) -o $(EXEC) $(OBJS) $(LIBS) #-Bdynamic
+		mv $(EXEC) ../bin/
+#--------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------
+#  Tar Up Code                           
+#--------------------------------------------------------------------------
+
+tarfile:
+	tar cvf funwave_tvd.tar *.F  Makefile
+
+#--------------------------------------------------------------------------
+#  Cleaning targets.
+#--------------------------------------------------------------------------
+
+clean:
+		/bin/rm -f *.o *.mod
+
+clobber:	clean
+		/bin/rm -f *.f90 *.o $(EXEC)
+

--- a/src/fluxes.F
+++ b/src/fluxes.F
@@ -789,21 +789,21 @@ SUBROUTINE CONSTRUCTION_HO_minmod
 !ykchoi]
 
 ! construct in x-direction
-     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,U,UxL,UxR)
-     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,V,VxL,VxR)
-     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,HU,HUxL,HUxR)
-     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,HV,HVxL,HVxR)
-     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,Eta,EtaRxL,EtaRxR)
+     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,U,UxL,UxR)
+     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,V,VxL,VxR)
+     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,HU,HUxL,HUxR)
+     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,HV,HVxL,HVxR)
+     CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,Eta,EtaRxL,EtaRxR)
 
 ! dispersion
      HxL=EtaRxL+Depthx
      HxR=EtaRxR+Depthx
 # if defined (CARTESIAN)
      IF(DISPERSION)THEN
-      CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,U4,U4xL,U4xR)
+      CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,U4,U4xL,U4xR)
 	  
 	!ykchoi :: Following V4xL, V4xR terms should be computed.
-	CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,V4,V4xL,V4xR)  
+	CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,V4,V4xL,V4xR)  
      ENDIF
 
 !ykchoi (09.07.2015)
@@ -828,10 +828,10 @@ SUBROUTINE CONSTRUCTION_HO_minmod
 # else
 # if defined(ZALPHA)
      IF(DISPERSION)THEN
-      CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,U4,U4xL,U4xR)
+      CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,U4,U4xL,U4xR)
 
 	!ykchoi :: Following V4xL, V4xR terms should be computed.
-	CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,DX,MASK,V4,V4xL,V4xR)
+	CALL CONSTRUCT_HO_X(Mloc,Nloc,Mloc1,Ibeg,Iend,Jbeg,Jend,MASK,V4,V4xL,V4xR)
      ENDIF
 
      PL(1:Mloc1,1:Nloc)=HUxL(1:Mloc1,1:Nloc) &
@@ -883,21 +883,21 @@ SUBROUTINE CONSTRUCTION_HO_minmod
 # endif
       
 ! construct in y-direction
-     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,U,UyL,UyR)
-     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,V,VyL,VyR)
-     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,HV,HVyL,HVyR)
-     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,HU,HUyL,HUyR)
-     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,Eta,EtaRyL,EtaRyR)
+     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,U,UyL,UyR)
+     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,V,VyL,VyR)
+     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,HV,HVyL,HVyR)
+     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,HU,HUyL,HUyR)
+     CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,Eta,EtaRyL,EtaRyR)
 
 ! dispersion
      HyL=EtaRyL+Depthy
      HyR=EtaRyR+Depthy
 # if defined (CARTESIAN)
      IF(DISPERSION)THEN
-       CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,V4,V4yL,V4yR)
+       CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,V4,V4yL,V4yR)
 
 	 !ykchoi :: Following U4yL, U4yR terms should be computed.
-	 CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,U4,U4yL,U4yR)
+	 CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,U4,U4yL,U4yR)
      ENDIF
 
      QL(1:Mloc,1:Nloc1)=HVyL(1:Mloc,1:Nloc1)   &
@@ -920,10 +920,10 @@ SUBROUTINE CONSTRUCTION_HO_minmod
 
 # if defined (ZALPHA)
      IF(DISPERSION)THEN
-       CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,V4,V4yL,V4yR)
+       CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,V4,V4yL,V4yR)
 
 	 !ykchoi :: Following U4yL, U4yR terms should be computed.
-	 CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,DY,MASK,U4,U4yL,U4yR)
+	 CALL CONSTRUCT_HO_Y(Mloc,Nloc,Nloc1,Ibeg,Iend,Jbeg,Jend,MASK,U4,U4yL,U4yR)
      ENDIF
 
      QL(1:Mloc,1:Nloc1)=HVyL(1:Mloc,1:Nloc1)   &

--- a/src/io.F
+++ b/src/io.F
@@ -587,6 +587,8 @@ SUBROUTINE READ_INPUT
          ENDIF
 # if defined (INTEL)
           Phase_Ser(J)=rand()*2.0_SP*3.1415926
+# elif defined (CRAY)
+          Phase_Ser(J)=rand()*2.0_SP*3.1415926
 # else
           Phase_Ser(J)=rand(0)*2.0_SP*3.1415926
 # endif

--- a/src/wavemaker.F
+++ b/src/wavemaker.F
@@ -221,6 +221,8 @@ SUBROUTINE WAVEMAKER_INITIALIZATION
        DO I=1,NumDir
 # if defined (INTEL)
           Phase2D(J,I)=rand()*2.0_SP*pi
+# elif define (CRAY)
+          Phase2D(J,I)=rand()*2.0_SP*pi
 # else
           Phase2D(J,I)=rand(0)*2.0_SP*pi
 # endif
@@ -771,6 +773,8 @@ SUBROUTINE CALCULATE_TMA_Cm_Sm &
        DO kf=1,NumFreq
 # if defined (INTEL)
           Phase_Ser(kf)=rand()*2.0_SP*3.1415926
+# elif defined (CRAY)
+          Phase_Ser(kf)=rand()*2.0_SP*3.1415926
 # else
           Phase_Ser(kf)=rand(0)*2.0_SP*3.1415926
 # endif
@@ -1285,6 +1289,8 @@ SUBROUTINE WK_WAVEMAKER_IRREGULAR_WAVE &
         do ktheta=1,mtheta
         do kf=1,mfreq
 # if defined (INTEL)
+          phi1(kf,ktheta)=rand()*2.0_SP*pi
+# elif defined (CRAY)
           phi1(kf,ktheta)=rand()*2.0_SP*pi
 # else
           phi1(kf,ktheta)=rand(0)*2.0_SP*pi


### PR DESCRIPTION
Cleaned up `io.F` and `fluxes.F` with regards to signature mismatch (11 vs 12 positional parameters passed to `CONSTRUCTION_HO_X` AND `CONSTRUCTION_HO_Y`) and Cray compiler issues with `rand()` function extended definition. Added two Makefiles for Lightning (intel and cray compiles) -- code checks out OK as I've ran FRF 1D test case on it.