### PR TITLE
Make it easier for users to spot errors they made in compiling or running Funwave-TVD.

### DIFF
--- a/src/io.F
+++ b/src/io.F
@@ -231,6 +231,7 @@ SUBROUTINE READ_INPUT
       CALL READ_FLOAT(DX,FILE_NAME,'DX',ierr)
 
       IF(ierr==1)THEN
+         PRINT *,"Did you intend to use Spherical Coordinates?"
 # if defined (PARALLEL)
       if (myid.eq.0) THEN
          WRITE(*,'(A40,A40)')'DX:', 'NOT DEFINED, STOP'

--- a/src/misc.F
+++ b/src/misc.F
@@ -83,7 +83,7 @@ SUBROUTINE INDEX
    if( nprocs /= NumberProcessor) then
      if( myid==0 ) then
 	 print *, '======================================================='
-       print *, '*** STOP :: Number of processors in MPIRUN /= Px*Py ***'
+       print *, '*** STOP :: Number of processors(',nprocs,') in MPIRUN /= Px*Py(',PX*PY,') ***'
 	 print *, '======================================================='
      endif
      call MPI_FINALIZE ( ier )

--- a/src/mod_storm.F
+++ b/src/mod_storm.F
@@ -290,6 +290,11 @@ SUBROUTINE STORM_FORCING
     ENDDO
     ENDDO
 
+#ifndef CARTESIAN
+#ifdef STORM
+#error "Please compile without -DSTORM when -DCARTESIAN is not set."
+#endif
+#endif
 
     DO J=Jbeg,Jend
     DO I=Ibeg,Iend


### PR DESCRIPTION
This helps identify if you have CARTESIAN set when you should not, or if you have STORM enabled when you should not. It also helps you to provide the correct number of processors if you invoke the code incorrectly.