### PR TITLE
Makefile build script for Onyx under Intel PrgEnv

### DIFF
--- a/src/Makefile-Onyx-intel
+++ b/src/Makefile-Onyx-intel
@@ -1,0 +1,104 @@
+#-----------BEGIN MAKEFILE-------------------------------------------------
+            SHELL         = /bin/sh
+            DEF_FLAGS     = -P -traditional 
+            EXEC          = funwave_intel
+#==========================================================================
+#--------------------------------------------------------------------------
+#        PRECISION          DEFAULT PRECISION: SINGLE                     
+#                           UNCOMMENT TO SELECT DOUBLE PRECISION
+#--------------------------------------------------------------------------
+
+            FLAG_1 = -DDOUBLE_PRECISION 
+            FLAG_2 = -DPARALLEL
+            FLAG_3 = -DSAMPLES
+            FLAG_4 = -DCARTESIAN
+#	    FLAG_5 = -DVESSEL
+            FLAG_6 = -DINTEL
+#             FLAG_7 = -DMIXING
+#             FLAG_8 = -DCOUPLING
+#             FLAG_9 = -DZALPHA
+#             FLAG_10 = -DMANNING
+
+#--------------------------------------------------------------------------
+#  mpi defs 
+#--------------------------------------------------------------------------
+         CPP      = /usr/bin/cpp 
+         CPPFLAGS = $(DEF_FLAGS)
+         FC       = ftn
+         DEBFLGS  = 
+         OPT      = 
+         CLIB     = 
+#==========================================================================
+
+         FFLAGS = $(DEBFLGS) $(OPT) #-fPIC -g -O2
+         MDEPFLAGS = --cpp --fext=f90 --file=-
+         RANLIB = ranlib
+	 MPILIB = 
+#--------------------------------------------------------------------------
+#  CAT Preprocessing Flags
+#--------------------------------------------------------------------------
+           CPPARGS = $(CPPFLAGS) $(DEF_FLAGS) $(FLAG_1) $(FLAG_2) \
+			$(FLAG_3) $(FLAG_4) $(FLAG_5) $(FLAG_6) \
+			$(FLAG_7) $(FLAG_8) $(FLAG_9) $(FLAG_10)  \
+			$(FLAG_11) $(FLAG_12) $(FLAG_13) $(FLAG_14) \
+			$(FLAG_15) $(FLAG_16) $(FLAG_17) $(FLAG_18) \
+			$(FLAG_19) $(FLAG_20) $(FLAG_21) $(FLAG_22) \
+			$(FLAG_23) $(FLAG_24)
+#--------------------------------------------------------------------------
+#  Libraries           
+#--------------------------------------------------------------------------
+
+            LIBS  = $(PV3LIB) $(CLIB)  $(PARLIB) $(IOLIBS) $(MPILIB) $(GOTMLIB)
+#            INCS  = $(IOINCS) $(GOTMINCS)
+
+
+#--------------------------------------------------------------------------
+#  Preprocessing and Compilation Directives
+#--------------------------------------------------------------------------
+.SUFFIXES: .o .f90 .F .F90 
+
+.F.o:
+	$(CPP) $(CPPARGS) $*.F > $*.f90
+	$(FC)  -c $(FFLAGS) $(INCS) $*.f90
+#	\rm $*.f90
+#--------------------------------------------------------------------------
+#  FUNWAVE-TVD Source Code.
+#--------------------------------------------------------------------------
+
+MODS  = mod_param.F	mod_global.F	mod_input.F mod_vessel.F  mod_bathy_correction.F \
+        mod_parallel_field_io.F mod_meteo.F
+
+MAIN  = main.F bc.F fluxes.F init.F io.F tridiagnal.F       \
+        breaker.F derivatives.F dispersion.F etauv_solver.F \
+        sponge.F sources.F masks.F parallel.F statistics.F \
+        wavemaker.F mixing.F nesting.F misc.F samples.F\
+
+SRCS = $(MODS)  $(MAIN)
+
+OBJS = $(SRCS:.F=.o)
+
+#--------------------------------------------------------------------------
+#  Linking Directives               
+#--------------------------------------------------------------------------
+
+$(EXEC):	$(OBJS)
+		$(FC) $(FFLAGS) $(LDFLAGS) -o $(EXEC) $(OBJS) $(LIBS)
+		mv $(EXEC) ../bin/
+#--------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------
+#  Tar Up Code                           
+#--------------------------------------------------------------------------
+
+tarfile:
+	tar cvf funwave_tvd.tar *.F  Makefile
+
+#--------------------------------------------------------------------------
+#  Cleaning targets.
+#--------------------------------------------------------------------------
+
+clean:
+		/bin/rm -f *.o *.mod *.f90
+
+clobber:	clean
+		/bin/rm -f *.f90 *.o $(EXEC)


### PR DESCRIPTION
Added a new Makefile (Makefile-Onyx-intel) for the new HPC system Onyx under (non-default) programming environment (PrEnv Intel).