### PR TITLE
Fixed bug in CHECK_BLOWUP subroutine not exiting simulation correctly…

### DIFF
--- a/src/misc.F
+++ b/src/misc.F
@@ -411,8 +411,10 @@ SUBROUTINE CHECK_BLOWUP
 	   ICOUNT=99998;
 	   CALL PREVIEW
 
-# if defined (PARALLEL)
-     call MPI_FINALIZE ( ier )
+# if defined (PARALLEL
+     ! 2019/09/04 mayhl: Switched MPI_FINALIZE to MPI_ABORT 
+     !call MPI_FINALIZE ( ier )
+     call MPI_ABORT( MPI_COMM_WORLD , 9 , ier )
 # else
      STOP
 # endif


### PR DESCRIPTION
… in all cases. Switched MPI_FINALIZED command to MPI_ABORT. 