### PR TITLE
Update mixing.F

### DIFF
--- a/src/mixing.F
+++ b/src/mixing.F
@@ -233,8 +233,8 @@ END SUBROUTINE MIXING_STUFF
        DO J=1,N
        DO I=1,M
         IF(Num_Zero_Up(I,J)>=2)THEN
-          WaveHeightAve(I,J)=HavgSum(I,J)/Num_Zero_Up(I,J)
-          WaveHeightRMS(I,J)=SQRT(HrmsSum(I,J)/Num_Zero_Up(I,J))
+          WaveHeightAve(I,J)=HavgSum(I,J)/(Num_Zero_Up(I,J)-1)
+          WaveHeightRMS(I,J)=SQRT(HrmsSum(I,J)/(Num_Zero_Up(I,J)-1))
         ENDIF
 !        Num_Zero_Up(I,J)=0
 !        HavgSum(I,J)=ZERO


### PR DESCRIPTION
There was a bug in WaveHeightAve and WaveHeightRMS calculations. Namely, the number of zero-up crossings and wave heights did not match. Num_Zero_Up in the denominator should be decreased by one.