### PR TITLE
Fix wavemaker.F when PARALLEL is not defined

### DIFF
--- a/src/wavemaker.F
+++ b/src/wavemaker.F
@@ -3052,6 +3052,8 @@ SUBROUTINE CALCULATE_NEW_Cm_Sm(M,N,DX,DY,Xc,Ibeg,Jbeg,mfreq,mtheta,D_gen,&
     USE GLOBAL, ONLY : myid,npx,npy,px,py,Mglob,Nglob, &
         iista,jjsta,&   !ykchoi Jan/23/2018
         loop_index,Freq !Chen, Salatin
+# else
+    USE GLOBAL, ONLY : Freq, loop_index
 # endif
     IMPLICIT NONE
     INTEGER,INTENT(IN) :: M,N,mfreq,mtheta,Ibeg,Jbeg


### PR DESCRIPTION
The source file src/wavemaker.F will fail to build if PARALLEL is not defined because two variables are not pulled in from the GLOBAL module.  This change does pull them in correctly to allow the build to proceed.

Also, the file appears to be a mixed collection of line end characters.  GitHub has changed them all to Windows line endings.  The only change of any significance is src/wavemaker.F:3055